### PR TITLE
Delete useless artifacts declared in pom.xml

### DIFF
--- a/perk-store-services/pom.xml
+++ b/perk-store-services/pom.xml
@@ -56,21 +56,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,6 @@
     <!-- 3rd party libraries versions -->
     <org.exoplatform.platform.version>5.3.x-SNAPSHOT</org.exoplatform.platform.version>
 
-    <org.jackson.version>2.4.0</org.jackson.version>
-
     <!-- Used to generate default methods for POJO -->
     <org.lombok.version>1.18.2</org.lombok.version>
     <org.lombok.plugin.version>1.18.0.0</org.lombok.plugin.version>
@@ -76,32 +74,6 @@
         <scope>provided</scope>
       </dependency>
 
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>${org.jackson.version}</version>
-        <scope>provided</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15on</artifactId>
-        <version>${org.bouncycastle.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${org.jackson.version}</version>
-        <scope>provided</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>${org.jackson.version}</version>
-        <scope>provided</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>


### PR DESCRIPTION
the artifacts com.fasterxml.jackson.core 2.4.0 are outdated, thus those artifacts should be deleted to reuse the same version decalred in eXo platform libraries