### PR TITLE
MAINT-25738: Allow enable/disable perkstore portal configuration override

### DIFF
--- a/perk-store-webapps/src/main/webapp/WEB-INF/conf/perk-store/portal-configuration.xml
+++ b/perk-store-webapps/src/main/webapp/WEB-INF/conf/perk-store/portal-configuration.xml
@@ -23,7 +23,7 @@
               <boolean>${exo.perkstore.portalConfig.metadata.override:true}</boolean>
             </field>
             <field name="importMode">
-              <string>${exo.perkstore.portalConfig.metadata.importmode:merge}</string>
+              <string>${exo.perkstore.portalConfig.metadata.importmode:insert}</string>
             </field>
             <field name="predefinedOwner">
               <collection type="java.util.HashSet">

--- a/perk-store-webapps/src/main/webapp/WEB-INF/conf/perk-store/portal-configuration.xml
+++ b/perk-store-webapps/src/main/webapp/WEB-INF/conf/perk-store/portal-configuration.xml
@@ -20,10 +20,10 @@
               <string>portal</string>
             </field>
             <field name="override">
-              <boolean>true</boolean>
+              <boolean>${exo.perkstore.portalConfig.metadata.override:true}</boolean>
             </field>
             <field name="importMode">
-              <string>merge</string>
+              <string>${exo.perkstore.portalConfig.metadata.importmode:merge}</string>
             </field>
             <field name="predefinedOwner">
               <collection type="java.util.HashSet">


### PR DESCRIPTION
This allows to enable or disable the override of persk store configuration with needed properties exo.perkstore.portalConfig.metadata.override and exo.perkstore.portalConfig.metadata.importmode